### PR TITLE
fix: mocked request headers and DiffDialog crash

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -475,9 +475,7 @@ chrome.debugger.onEvent.addListener(async (source, method, params) => {
           type: 'fetch',
           method: reqMethod,
           url,
-          requestHeaders: Object.fromEntries(
-            (params.request.headers || []).map(h => [h.name, h.value])
-          ),
+          requestHeaders: params.request.headers || {},
           requestBody: params.request.postData || null,
           status: matchedMock.status || 200,
           statusText: 'OK (Mocked)',

--- a/src/sidepanel/components/views/DiffDialog.tsx
+++ b/src/sidepanel/components/views/DiffDialog.tsx
@@ -85,7 +85,7 @@ export function DiffDialog({
             <div className="flex-1 px-4 py-2 border-r border-border bg-surface">
               <div className="flex items-center gap-2">
                 <span className="text-[10px] font-mono font-semibold text-emerald-600">{req1.method}</span>
-                <span className="text-[10px] text-text-muted truncate">{new URL(req1.url).pathname}</span>
+                <span className="text-[10px] text-text-muted truncate">{(() => { try { return new URL(req1.url).pathname } catch { return req1.url } })()}</span>
               </div>
               <div className="text-[10px] text-text-muted mt-0.5">
                 Status: {req1.status} • {req1.duration}ms
@@ -94,7 +94,7 @@ export function DiffDialog({
             <div className="flex-1 px-4 py-2 bg-surface">
               <div className="flex items-center gap-2">
                 <span className="text-[10px] font-mono font-semibold text-blue-600">{req2.method}</span>
-                <span className="text-[10px] text-text-muted truncate">{new URL(req2.url).pathname}</span>
+                <span className="text-[10px] text-text-muted truncate">{(() => { try { return new URL(req2.url).pathname } catch { return req2.url } })()}</span>
               </div>
               <div className="text-[10px] text-text-muted mt-0.5">
                 Status: {req2.status} • {req2.duration}ms


### PR DESCRIPTION
## Summary

Bug fixes found during feature audit:

- **Mocked request headers empty** — `Fetch.requestPaused` incorrectly treated `params.request.headers` as an array of `{name, value}` objects, but CDP returns it as a plain object. All mocked requests had empty `requestHeaders` in the UI and exports.
- **DiffDialog crash** — `new URL(req.url).pathname` called without try/catch. Any malformed or relative URL crashed the diff comparison view.

## Test plan

- [ ] Create a mock rule, trigger a matching request — verify request headers appear in the detail panel
- [ ] Compare two requests in diff view where one has a relative/malformed URL — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)